### PR TITLE
Improve HTTP server demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ Makefile.apt
 slask*
 fel
 fil
+demo/simple_http_server
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ slask*
 fel
 fil
 demo/simple_http_server
+demo/output.html
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ fil
 demo/simple_http_server
 demo/output.html
 
+demo/tests/http_server_test

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,13 @@
+CXX=g++
+CXXFLAGS=`../src/Sockets-config` -I../src -Wall
+LDFLAGS=
+LIBS=../src/libSockets.a -lssl -lcrypto -lpthread
+
+all: simple_http_server
+
+simple_http_server: simple_http_server.o
+	$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
+
+clean:
+	rm -f simple_http_server.o simple_http_server
+

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CppSockets Demo</title>
+</head>
+<body>
+    <h1>Hello from CppSockets demo server!</h1>
+</body>
+</html>

--- a/demo/simple_http_server.cpp
+++ b/demo/simple_http_server.cpp
@@ -1,0 +1,71 @@
+#include "HttpdSocket.h"
+#include "SocketHandler.h"
+#include "ListenSocket.h"
+#include "StdoutLog.h"
+#include "Utility.h"
+#include <fstream>
+
+#ifdef SOCKETS_NAMESPACE
+using namespace SOCKETS_NAMESPACE;
+#endif
+
+// Simple HTTP server socket that always serves "index.html"
+class IndexSocket : public HttpdSocket
+{
+public:
+    IndexSocket(ISocketHandler& h) : HttpdSocket(h) {}
+
+    void Exec() override
+    {
+        std::ifstream file("index.html", std::ios::binary);
+        if (!file.is_open())
+        {
+            const std::string msg = "index.html not found\n";
+            SetStatus("404");
+            SetStatusText("Not Found");
+            AddResponseHeader("Content-type", "text/plain");
+            AddResponseHeader("Content-length", Utility::l2string((long)msg.size()));
+            AddResponseHeader("Connection", "close");
+            SendResponse();
+            Send(msg);
+            SetCloseAndDelete();
+            return;
+        }
+
+        std::string content((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+
+        SetStatus("200");
+        SetStatusText("OK");
+        AddResponseHeader("Content-type", "text/html");
+        AddResponseHeader("Content-length", Utility::l2string((long)content.size()));
+        AddResponseHeader("Connection", "close");
+        SendResponse();
+        if (!content.empty())
+        {
+            SendBuf(const_cast<char*>(content.data()), content.size());
+        }
+        SetCloseAndDelete();
+    }
+
+private:
+};
+
+int main(int argc, char* argv[])
+{
+    StdoutLog log;
+    SocketHandler h(&log);
+    ListenSocket<IndexSocket> server(h);
+    if (server.Bind(8080))
+    {
+        fprintf(stderr, "Failed to bind port 8080\n");
+        return 1;
+    }
+    h.Add(&server);
+    while (h.GetCount())
+    {
+        h.Select(1, 0);
+    }
+    return 0;
+}
+

--- a/demo/test.sh
+++ b/demo/test.sh
@@ -20,3 +20,18 @@ else
 fi
 rm -f output.html
 
+# Test missing index.html case
+mv index.html index.html.bak
+./simple_http_server &
+PID=$!
+sleep 1
+curl -s http://127.0.0.1:8080/ > output.html
+kill $PID
+grep -q "index.html not found" output.html && echo "404 handled" || {
+  echo "Missing file handling failed" >&2
+  mv index.html.bak index.html
+  exit 1
+}
+mv index.html.bak index.html
+rm -f output.html
+

--- a/demo/test.sh
+++ b/demo/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+cd "$(dirname "$0")"
+# Build library and demo
+make -C ../src -j2 >/dev/null
+make >/dev/null
+# Start server in background
+./simple_http_server &
+PID=$!
+sleep 1
+# Fetch page
+curl -s http://127.0.0.1:8080/ > output.html
+kill $PID
+# Compare with reference
+if diff -u index.html output.html; then
+  echo "Output matches index.html"
+else
+  echo "Output differs" >&2
+  exit 1
+fi
+rm -f output.html
+

--- a/demo/tests/Makefile
+++ b/demo/tests/Makefile
@@ -1,0 +1,11 @@
+CXX=g++
+CXXFLAGS=`../../src/Sockets-config` -I../../src `pkg-config --cflags cppunit` -Wall
+LIBS=../../src/libSockets.a `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
+
+all: http_server_test
+
+http_server_test: http_server_test.o
+	$(CXX) -o $@ $^ $(LIBS)
+
+clean:
+	rm -f http_server_test.o http_server_test

--- a/demo/tests/http_server_test.cpp
+++ b/demo/tests/http_server_test.cpp
@@ -1,0 +1,77 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <fstream>
+#include <iterator>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <string>
+
+class HttpServerTest : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(HttpServerTest);
+    CPPUNIT_TEST(testIndexHtml);
+    CPPUNIT_TEST(testMissingIndexHtml);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override {}
+    void tearDown() override {}
+
+    void startServer(pid_t &pid)
+    {
+        pid = fork();
+        if (pid == 0) {
+            execl("./simple_http_server", "./simple_http_server", nullptr);
+            std::exit(1);
+        }
+        sleep(1);
+    }
+
+    void stopServer(pid_t pid)
+    {
+        kill(pid, SIGTERM);
+        waitpid(pid, nullptr, 0);
+    }
+
+    void testIndexHtml()
+    {
+        system("make -C ../src -j2 >/dev/null");
+        system("make >/dev/null");
+        pid_t pid;
+        startServer(pid);
+        system("curl -s http://127.0.0.1:8080/ > output.html");
+        stopServer(pid);
+        std::ifstream expected("index.html", std::ios::binary);
+        std::string exp((std::istreambuf_iterator<char>(expected)), {});
+        std::ifstream actual("output.html", std::ios::binary);
+        std::string act((std::istreambuf_iterator<char>(actual)), {});
+        std::remove("output.html");
+        CPPUNIT_ASSERT_EQUAL(exp, act);
+    }
+
+    void testMissingIndexHtml()
+    {
+        std::rename("index.html", "index.html.bak");
+        system("make -C ../src -j2 >/dev/null");
+        system("make >/dev/null");
+        pid_t pid;
+        startServer(pid);
+        system("curl -s http://127.0.0.1:8080/ > output.html");
+        stopServer(pid);
+        std::ifstream actual("output.html", std::ios::binary);
+        std::string act((std::istreambuf_iterator<char>(actual)), {});
+        std::remove("output.html");
+        std::rename("index.html.bak", "index.html");
+        CPPUNIT_ASSERT(act.find("index.html not found") != std::string::npos);
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(HttpServerTest);
+
+int main()
+{
+    CppUnit::TextUi::TestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+    return runner.run() ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- refine example HTTP server for clarity and proper headers
- add script that fetches the served page and compares to `index.html`
- ignore demo executable

## Testing
- `make -C src -j2`
- `make -C demo`
- `./demo/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684149a3824c832292d50dbc1447eb9f