### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/src/Ajp13Socket.cpp
+++ b/src/Ajp13Socket.cpp
@@ -57,7 +57,7 @@ Ajp13Socket::Ajp13Socket(ISocketHandler& h) : AjpBaseSocket(h)
 
 
 // --------------------------------------------------------------------------------------
-void Ajp13Socket::OnHeader( short id, short len )
+void Ajp13Socket::OnHeader( short id, short /*len*/ )
 {
 	if (id != 0x1234)
 	{
@@ -119,7 +119,7 @@ DEB(		fprintf(stderr, "More body data received than expected\n");)
 
 
 // --------------------------------------------------------------------------------------
-void Ajp13Socket::ReceiveForwardRequest( const char *buf, size_t sz )
+void Ajp13Socket::ReceiveForwardRequest( const char *buf, size_t /*sz*/ )
 {
 	//
 	int ptr = 0;
@@ -230,19 +230,19 @@ DEB(					fprintf(stderr, "Unknown attribute key: 0x%02x\n", buf[ptr]);)
 
 
 // --------------------------------------------------------------------------------------
-void Ajp13Socket::ReceiveShutdown( const char *buf, size_t sz )
+void Ajp13Socket::ReceiveShutdown( const char * /*buf*/, size_t /*sz*/ )
 {
 }
 
 
 // --------------------------------------------------------------------------------------
-void Ajp13Socket::ReceivePing( const char *buf, size_t sz )
+void Ajp13Socket::ReceivePing( const char * /*buf*/, size_t /*sz*/ )
 {
 }
 
 
 // --------------------------------------------------------------------------------------
-void Ajp13Socket::ReceiveCPing( const char *buf, size_t sz )
+void Ajp13Socket::ReceiveCPing( const char * /*buf*/, size_t /*sz*/ )
 {
        char msg[5]; 
        msg[0] = 'A';

--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -339,7 +339,7 @@ DEB(fprintf(stderr, " *** AddCookie '%s' = '%s'\n", name.c_str(), lstr.c_str());
 
 
 // --------------------------------------------------------------------------------------
-void HttpRequest::InitBody( size_t sz )
+void HttpRequest::InitBody( size_t /*sz*/ )
 {
 	if (!m_body_file.get())
 		m_body_file = USING_AUTOPTR_AS<IFile>(new MemFile);

--- a/src/HttpdSocket.h
+++ b/src/HttpdSocket.h
@@ -88,7 +88,7 @@ protected:
 	std::string m_if_modified_since;
 
 private:
-	HttpdSocket& operator=(const HttpdSocket& s) { return *this; }
+        HttpdSocket& operator=(const HttpdSocket& /*s*/) { return *this; }
 static	int m_request_count;
 static	std::string m_start;
 	size_t m_content_length;

--- a/src/MemFile.cpp
+++ b/src/MemFile.cpp
@@ -126,7 +126,7 @@ MemFile::~MemFile()
 }
 
 
-bool MemFile::fopen(const std::string& path, const std::string& mode)
+bool MemFile::fopen(const std::string& /*path*/, const std::string& /*mode*/)
 {
 	return true;
 }

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -83,7 +83,7 @@ Parse::Parse(const std::string&s,const std::string&sp)
 {
 }
 
-Parse::Parse(const std::string&s,const std::string&sp,short nospace)
+Parse::Parse(const std::string&s,const std::string&sp,short /*nospace*/)
 :pa_the_str(s)
 ,pa_splits(sp)
 ,pa_ord("")

--- a/src/ResolvSocket.cpp
+++ b/src/ResolvSocket.cpp
@@ -77,7 +77,7 @@ ResolvSocket::ResolvSocket(ISocketHandler& h)
 }
 
 
-ResolvSocket::ResolvSocket(ISocketHandler& h, Socket *parent, const std::string& host, port_t port, bool ipv6)
+ResolvSocket::ResolvSocket(ISocketHandler& h, Socket *parent, const std::string& host, port_t port, bool /*ipv6*/)
 :TcpSocket(h)
 ,m_bServer(false)
 ,m_parent(parent)

--- a/src/SSLInitializer.cpp
+++ b/src/SSLInitializer.cpp
@@ -131,7 +131,7 @@ void SSLInitializer::DeleteRandFile()
 }
 
 
-void SSLInitializer::SSL_locking_function(int mode, int n, const char *file, int line)
+void SSLInitializer::SSL_locking_function(int mode, int n, const char * /*file*/, int /*line*/)
 {
 	IMutex *mutex = NULL;
 	{

--- a/src/TcpSocket.cpp
+++ b/src/TcpSocket.cpp
@@ -125,7 +125,7 @@ TcpSocket::TcpSocket(ISocketHandler& h) : StreamSocket(h)
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif
-TcpSocket::TcpSocket(ISocketHandler& h,size_t isize,size_t osize) : StreamSocket(h)
+TcpSocket::TcpSocket(ISocketHandler& h,size_t isize,size_t /*osize*/) : StreamSocket(h)
 ,ibuf(isize)
 ,m_b_input_buffer_disabled(false)
 ,m_bytes_sent(0)
@@ -212,6 +212,9 @@ bool TcpSocket::Open(SocketAddress& ad,bool skip_socks)
 
 bool TcpSocket::Open(SocketAddress& ad,SocketAddress& bind_ad,bool skip_socks)
 {
+#ifndef ENABLE_SOCKS4
+       (void)skip_socks;
+#endif
 	if (!ad.IsValid())
 	{
 		Handler().LogError(this, "Open", 0, "Invalid SocketAddress", LOG_LEVEL_FATAL);
@@ -1380,7 +1383,7 @@ void TcpSocket::UseCertificateChainFile(const std::string& filename)
 }
 
 
-int TcpSocket::SSL_password_cb(char *buf,int num,int rwflag,void *userdata)
+int TcpSocket::SSL_password_cb(char *buf,int num,int /*rwflag*/,void *userdata)
 {
 	Socket *p0 = static_cast<Socket *>(userdata);
 	TcpSocket *p = dynamic_cast<TcpSocket *>(p0);
@@ -1463,7 +1466,7 @@ void TcpSocket::SetReconnect(bool x)
 #endif
 
 
-void TcpSocket::OnRawData(const char *buf_in,size_t len)
+void TcpSocket::OnRawData(const char * /*buf_in*/,size_t /*len*/)
 {
 }
 
@@ -1540,7 +1543,7 @@ void TcpSocket::DisableInputBuffer(bool x)
 }
 
 
-void TcpSocket::OnOptions(int family,int type,int protocol,SOCKET s)
+void TcpSocket::OnOptions(int /*family*/,int /*type*/,int /*protocol*/,SOCKET /*s*/)
 {
 DEB(	fprintf(stderr, "Socket::OnOptions()\n");)
 #ifdef SO_NOSIGPIPE

--- a/src/UdpSocket.cpp
+++ b/src/UdpSocket.cpp
@@ -56,7 +56,7 @@ namespace SOCKETS_NAMESPACE {
 #endif
 
 
-UdpSocket::UdpSocket(ISocketHandler& h, int ibufsz, bool ipv6, int retries) : Socket(h)
+UdpSocket::UdpSocket(ISocketHandler& h, int ibufsz, bool /*ipv6*/, int retries) : Socket(h)
 , m_ibuf(new char[ibufsz])
 , m_ibufsz(ibufsz)
 , m_bind_ok(false)
@@ -709,6 +709,9 @@ bool UdpSocket::IsMulticastLoop()
 
 void UdpSocket::AddMulticastMembership(const std::string& group, const std::string& local_if, int if_index)
 {
+#if !defined(ENABLE_IPV6) || !defined(IPPROTO_IPV6)
+       (void)if_index;
+#endif
 	if (GetSocket() == INVALID_SOCKET)
 	{
 		CreateConnection();
@@ -750,6 +753,9 @@ void UdpSocket::AddMulticastMembership(const std::string& group, const std::stri
 
 void UdpSocket::DropMulticastMembership(const std::string& group, const std::string& local_if, int if_index)
 {
+#if !defined(ENABLE_IPV6) || !defined(IPPROTO_IPV6)
+       (void)if_index;
+#endif
 	if (GetSocket() == INVALID_SOCKET)
 	{
 		CreateConnection();
@@ -838,12 +844,12 @@ bool UdpSocket::IsBound()
 }
 
 
-void UdpSocket::OnRawData(const char *buf, size_t len, struct sockaddr *sa, socklen_t sa_len)
+void UdpSocket::OnRawData(const char * /*buf*/, size_t /*len*/, struct sockaddr * /*sa*/, socklen_t /*sa_len*/)
 {
 }
 
 
-void UdpSocket::OnRawData(const char *buf, size_t len, struct sockaddr *sa, socklen_t sa_len, struct timeval *ts)
+void UdpSocket::OnRawData(const char * /*buf*/, size_t /*len*/, struct sockaddr * /*sa*/, socklen_t /*sa_len*/, struct timeval * /*ts*/)
 {
 }
 
@@ -866,7 +872,7 @@ void UdpSocket::SetTimestamp(bool x)
 }
 
 
-void UdpSocket::SetMulticastDefaultInterface(ipaddr_t a, int if_index)
+void UdpSocket::SetMulticastDefaultInterface(ipaddr_t a, int /*if_index*/)
 {
 	struct in_addr x;
 	memcpy(&x.s_addr, &a, sizeof(x.s_addr));
@@ -879,7 +885,7 @@ void UdpSocket::SetMulticastDefaultInterface(ipaddr_t a, int if_index)
 
 #ifdef ENABLE_IPV6
 #ifdef IPPROTO_IPV6
-void UdpSocket::SetMulticastDefaultInterface(in6_addr a, int if_index)
+void UdpSocket::SetMulticastDefaultInterface(in6_addr a, int /*if_index*/)
 {
 	if (setsockopt(GetSocket(), IPPROTO_IPV6, IPV6_MULTICAST_IF, &if_index, sizeof(if_index)) == -1)
 	{

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -920,6 +920,9 @@ bool Utility::reverse(struct sockaddr *sa, socklen_t sa_len, std::string& hostna
 
 bool Utility::reverse(struct sockaddr *sa, socklen_t sa_len, std::string& hostname, std::string& service, int flags)
 {
+#ifdef NO_GETADDRINFO
+       (void)sa_len;
+#endif
 	hostname = "";
 	service = "";
 #ifdef NO_GETADDRINFO
@@ -1047,8 +1050,11 @@ bool Utility::reverse(struct sockaddr *sa, socklen_t sa_len, std::string& hostna
 bool Utility::u2service(const std::string& name, int& service, int ai_flags)
 {
 #ifdef NO_GETADDRINFO
-	// %!
-	return false;
+       (void)name;
+       (void)service;
+       (void)ai_flags;
+       // %!
+       return false;
 #else
 	struct addrinfo hints;
 	service = 0;


### PR DESCRIPTION
## Summary
- silence several unused parameter warnings by commenting out variable names or casting to void
- apply fixes across multiple modules

## Testing
- `make clean >/tmp/make.log && make -j$(nproc) 2>&1 | tee /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_684159b512b48322aa7228099097852b