### PR TITLE
Add epoll option to HTTP server demo

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,15 @@
 CXX=g++
 CXXFLAGS=-I../src -std=c++11 `pkg-config --cflags cppunit`
-LIBS=`pkg-config --libs cppunit`
+LIBS_CPPUNIT=`pkg-config --libs cppunit`
+LIBS_SOCKETS=$(LIBS_CPPUNIT) -L../src -lSockets -lssl -lcrypto -lxml2 -lpthread
 
-all: json_tests
+all: json_tests socket_handler_ep_tests
 
 json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
+
+socket_handler_ep_tests: socket_handler_ep_tests.cpp
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
 clean:
-	rm -f json_tests
+	rm -f json_tests socket_handler_ep_tests

--- a/tests/socket_handler_ep_tests.cpp
+++ b/tests/socket_handler_ep_tests.cpp
@@ -1,0 +1,42 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <memory>
+#include "../src/SocketHandlerEp.h"
+#include "../src/StdoutLog.h"
+
+class SocketHandlerEpTest : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(SocketHandlerEpTest);
+    CPPUNIT_TEST(testConstruct);
+    CPPUNIT_TEST(testFactoryCreate);
+    CPPUNIT_TEST(testSelectWithoutSockets);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testConstruct() {
+        StdoutLog log;
+        SocketHandlerEp h(&log);
+        CPPUNIT_ASSERT_EQUAL(0, (int)h.GetCount());
+    }
+
+    void testFactoryCreate() {
+        StdoutLog log;
+        SocketHandlerEp base(&log);
+        std::unique_ptr<ISocketHandler> h(base.Create(&log));
+        CPPUNIT_ASSERT(dynamic_cast<SocketHandlerEp*>(h.get()) != nullptr);
+    }
+
+    void testSelectWithoutSockets() {
+        StdoutLog log;
+        SocketHandlerEp h(&log);
+        CPPUNIT_ASSERT_EQUAL(0, h.Select(0, 0));
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(SocketHandlerEpTest);
+
+int main() {
+    CppUnit::TextUi::TestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+    return runner.run() ? 0 : 1;
+}
+


### PR DESCRIPTION
## Summary
- Prefer `std::make_unique` when instantiating `SocketHandler` implementations in demo server
- Add CppUnit tests covering basic `SocketHandlerEp` behavior and update tests Makefile to build them

## Testing
- `make -C src`
- `make -C demo`
- `make -C tests`
- `./tests/socket_handler_ep_tests`
- `./tests/json_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a42534897c8322bc94c74ed367ac32