### PR TITLE
Document dist packaging and fix create-dist script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 The C++ class library is a versatile and user-friendly tool for network programming. It wraps the Berkeley Sockets C API and works on a variety of platforms including Unix and Windows. The library has been widely adopted, both in commercial and open-source applications, and offers several advanced features such as SSL support, IPv6 compatibility, and various socket types (tcp, udp, sctp, http). The source code is freely available under the GNU GPL license or an alternative license.
 
 The library was designed to simplify the complexities of network programming and provide a single-threaded approach to managing multiple sockets. Instead of using the traditional C API, it provides a convenient Socket class that handles address translations and owns the file descriptor. The library also features callback methods such as OnRead(), OnWrite(), OnConnect(), and OnAccept(), to report events and handle logic related to the sockets. The sockets are monitored and managed using the Select() method in a SocketHandler class. The library has been tested on Linux, Windows 2000, and to some extent on Solaris and Mac OS X.
+
+## Building and Creating a Distribution
+
+The source code for the library lives in the `src/` directory. To build the
+library and package a redistributable archive containing the essential headers
+and binaries, run the following commands from the project root:
+
+```bash
+cd src
+make PLATFORM=linux-x86-64
+make dist PLATFORM=linux-x86-64
+```
+
+After the `dist` target completes, the top-level `dist/` folder will contain
+`bin`, `lib`, and `include` directories with the compiled utilities, static
+libraries, and header files required to use the library.

--- a/src/README
+++ b/src/README
@@ -53,6 +53,10 @@ Unix (and Cygwin/Mingw on windows)
 7.  If all builds ok, you'll find the static library file 'libSockets.a'
     in the build directory.
 
+8.  Run `make dist` to assemble a redistributable package. The command
+    populates a top-level `dist/` directory with `bin`, `lib`, and `include`
+    folders containing the compiled tools, libraries, and headers.
+
 
 When compiling the application, any flags used when compiling the library
 also needs to be present when including the library .h files. All flags

--- a/src/create-dist.sh
+++ b/src/create-dist.sh
@@ -3,7 +3,7 @@ DEST=../dist
 rm -rf $DEST
 mkdir -p $DEST/bin/
 wget https://www.alhem.net/tmp/artify -O $DEST/bin/artify
-export PATH=$PATH:`pwd`/dist/bin
-artify build Sockets.fc
+chmod +x $DEST/bin/artify
+$DEST/bin/artify build Sockets.fc
 unzip -d .. -o -q Sockets.zip
 rm -f Sockets.zip Sockets.json


### PR DESCRIPTION
## Summary
- Add instructions for building and generating a distribution package
- Explain the dist packaging process in the source README
- Fix create-dist.sh so downloaded tool is executable and correctly invoked

## Testing
- `make -C src PLATFORM=linux-x86-64`
- `make -C src dist PLATFORM=linux-x86-64`


------
https://chatgpt.com/codex/tasks/task_e_68a5da8fd710832295e54ffcd590cafc