### PR TITLE
Add stress test and unified cppunit runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+## Build configuration
+- Define `SOCKETS` as the `dist/` folder when consuming the Sockets library from Makefiles outside `src/`.
+- Use `$(SOCKETS)/bin/` for helper binaries such as `Sockets-config`.
+- Include headers from `$(SOCKETS)/include/`.
+- Link against libraries in `$(SOCKETS)/lib/`.

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,9 +1,9 @@
-SOCKETS=../src
+SOCKETS=../dist
 
 CXX=g++
-CXXFLAGS=`$(SOCKETS)/Sockets-config` -I$(SOCKETS) -Wall -std=c++17
+CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include -Wall -std=c++17
 LDFLAGS=
-LIBS=$(SOCKETS)/libSockets.a -lssl -lcrypto -lpthread
+LIBS=-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
 
 all: simple_http_server
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,15 +1,13 @@
-SOCKETS =	../dist
+SOCKETS=../src
 
 CXX=g++
-CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include -Wall
+CXXFLAGS=`$(SOCKETS)/Sockets-config` -I$(SOCKETS) -Wall -std=c++17
 LDFLAGS=
-LIBS=$(SOCKETS)/lib/libSockets.a -lssl -lcrypto -lpthread
+LIBS=$(SOCKETS)/libSockets.a -lssl -lcrypto -lpthread
 
 all: simple_http_server
 
-simple_http_server: simple_http_server.o
-	$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
+simple_http_server: simple_http_server.o ; $(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-clean:
-	rm -f simple_http_server.o simple_http_server
+clean: ; rm -f simple_http_server.o simple_http_server
 

--- a/demo/test.sh
+++ b/demo/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+ulimit -c unlimited
 cd "$(dirname "$0")"
 # Build library and demo
 make -C ../src -j2 >/dev/null

--- a/demo/tests/Makefile
+++ b/demo/tests/Makefile
@@ -1,8 +1,8 @@
-SOCKETS=../../src
+SOCKETS=../../dist
 
 CXX=g++
-CXXFLAGS=`$(SOCKETS)/Sockets-config` -I$(SOCKETS) `pkg-config --cflags cppunit` -Wall -std=c++17
-LIBS=$(SOCKETS)/libSockets.a `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
+CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include `pkg-config --cflags cppunit` -Wall -std=c++17
+LIBS=-L$(SOCKETS)/lib -lSockets `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
 
 all: http_server_test
 

--- a/demo/tests/Makefile
+++ b/demo/tests/Makefile
@@ -1,16 +1,14 @@
-SOCKETS =	../../dist
+SOCKETS=../../src
 
 CXX=g++
-CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include `pkg-config --cflags cppunit` -Wall
-LIBS=$(SOCKETS)/lib/libSockets.a `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
+CXXFLAGS=`$(SOCKETS)/Sockets-config` -I$(SOCKETS) `pkg-config --cflags cppunit` -Wall -std=c++17
+LIBS=$(SOCKETS)/libSockets.a `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
 
 all: http_server_test
 
-http_server_test: http_server_test.o
-	$(CXX) -o $@ $^ $(LIBS)
+http_server_test: http_server_test.o ; $(CXX) -o $@ $^ $(LIBS)
 
-clean:
-	rm -f http_server_test.o http_server_test
+clean: ; rm -f http_server_test.o http_server_test
 
-setup:
-	@echo No longer necessary
+setup: ; @echo No longer necessary
+

--- a/demo/tests/http_server_test.cpp
+++ b/demo/tests/http_server_test.cpp
@@ -5,14 +5,45 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <sys/resource.h>
 #include <cstdlib>
 #include <string>
 #include <filesystem>
+#include <vector>
+#include <thread>
+#include <cstdio>
+
+static std::filesystem::path repoRoot()
+{
+    static std::filesystem::path root;
+    if (root.empty())
+    {
+        auto p = std::filesystem::current_path();
+        while (!p.empty())
+        {
+            if (std::filesystem::exists(p / "demo") && std::filesystem::exists(p / "src"))
+            {
+                root = p;
+                break;
+            }
+            p = p.parent_path();
+        }
+        if (root.empty())
+            root = std::filesystem::current_path();
+    }
+    return root;
+}
+
+static std::filesystem::path demoDir()
+{
+    return repoRoot() / "demo";
+}
 
 class HttpServerTest : public CppUnit::TestFixture {
     CPPUNIT_TEST_SUITE(HttpServerTest);
     CPPUNIT_TEST(testIndexHtml);
     CPPUNIT_TEST(testMissingIndexHtml);
+    CPPUNIT_TEST(testMaxConnections);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -21,9 +52,14 @@ public:
 
     void startServer(pid_t &pid)
     {
+        struct rlimit rl;
+        rl.rlim_cur = RLIM_INFINITY;
+        rl.rlim_max = RLIM_INFINITY;
+        setrlimit(RLIMIT_CORE, &rl);
+
         pid = fork();
         if (pid == 0) {
-            chdir("..");
+            chdir(demoDir().c_str());
             execl("./simple_http_server", "./simple_http_server", nullptr);
             std::exit(1);
         }
@@ -36,41 +72,75 @@ public:
         waitpid(pid, nullptr, 0);
     }
 
+    void buildDemo()
+    {
+        std::string build_src = "make -C " + (repoRoot() / "src").string() + " -j2 >/dev/null";
+        std::string build_demo = "make -C " + demoDir().string() + " >/dev/null";
+        system(build_src.c_str());
+        system(build_demo.c_str());
+    }
+
     void testIndexHtml()
     {
-        system("make -C ../../src -j2 >/dev/null");
-        system("make -C .. >/dev/null");
+        buildDemo();
         pid_t pid;
         startServer(pid);
-        system("curl -s http://127.0.0.1:8080/ > output.html");
+        std::filesystem::path output = demoDir() / "output.html";
+        std::string cmd = "curl -s http://127.0.0.1:8080/ > " + output.string();
+        system(cmd.c_str());
         stopServer(pid);
-        std::ifstream expected("../index.html", std::ios::binary);
+        std::ifstream expected((demoDir() / "index.html").string(), std::ios::binary);
         std::string exp((std::istreambuf_iterator<char>(expected)), {});
-        std::ifstream actual("output.html", std::ios::binary);
+        std::ifstream actual(output.string(), std::ios::binary);
         std::string act((std::istreambuf_iterator<char>(actual)), {});
-        std::remove("output.html");
+        std::remove(output.string().c_str());
         CPPUNIT_ASSERT_EQUAL(exp, act);
     }
 
     void testMissingIndexHtml()
     {
-        std::rename("../index.html", "../index.html.bak");
-        system("make -C ../../src -j2 >/dev/null");
-        system("make -C .. >/dev/null");
+        std::filesystem::path index_html = demoDir() / "index.html";
+        std::filesystem::path backup = demoDir() / "index.html.bak";
+        std::rename(index_html.c_str(), backup.c_str());
+        buildDemo();
         pid_t pid;
         startServer(pid);
-        system("curl -s http://127.0.0.1:8080/ > output.html");
+        std::filesystem::path output = demoDir() / "output.html";
+        std::string cmd = "curl -s http://127.0.0.1:8080/ > " + output.string();
+        system(cmd.c_str());
         stopServer(pid);
-        std::ifstream actual("output.html", std::ios::binary);
+        std::ifstream actual(output.string(), std::ios::binary);
         std::string act((std::istreambuf_iterator<char>(actual)), {});
-        std::remove("output.html");
-        std::rename("../index.html.bak", "../index.html");
+        std::remove(output.string().c_str());
+        std::rename(backup.c_str(), index_html.c_str());
         CPPUNIT_ASSERT(act.find("index.html not found") != std::string::npos);
+    }
+
+    void testMaxConnections()
+    {
+        buildDemo();
+        pid_t pid;
+        startServer(pid);
+        const int MAX_CONN = 50;
+        std::vector<std::thread> threads;
+        std::vector<int> results(MAX_CONN);
+        for (int i = 0; i < MAX_CONN; ++i)
+        {
+            threads.emplace_back([i, &results]() {
+                results[i] = system("curl -s http://127.0.0.1:8080/ > /dev/null");
+            });
+        }
+        for (auto &t : threads)
+            t.join();
+        stopServer(pid);
+        for (int r : results)
+            CPPUNIT_ASSERT_EQUAL(0, r);
     }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(HttpServerTest);
 
+#ifndef COMBINED_TESTS
 int main(int argc, char* argv[])
 {
     std::filesystem::path exe_path = argv[0];
@@ -80,3 +150,5 @@ int main(int argc, char* argv[])
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
     return runner.run() ? 0 : 1;
 }
+#endif
+

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -4,7 +4,7 @@ INCLUDE =	-I$(SOCKETS)/include
 LIBS =		-L$(SOCKETS)/lib -lSockets
 #-L$(SOCKETS) -lSockets 
 
-CFLAGS =	`Sockets-config`
+CFLAGS =        `$(SOCKETS)/bin/Sockets-config`
 
 CFLAGS +=	-I.
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,17 +1,17 @@
-SOCKETS =	../dist
+SOCKETS=../src
 
 CXX=g++
-CXXFLAGS=-I$(SOCKETS)/include -std=c++11 `pkg-config --cflags cppunit`
+CXXFLAGS=-I$(SOCKETS)/include -std=c++17 `pkg-config --cflags cppunit`
 LIBS_CPPUNIT=`pkg-config --libs cppunit`
-LIBS_SOCKETS=$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2 -lpthread
+LIBS_SOCKETS=$(LIBS_CPPUNIT) -L$(SOCKETS) -lSockets -lssl -lcrypto -lxml2 -lpthread
 
-all: json_tests socket_handler_ep_tests
+all: json_tests socket_handler_ep_tests all_tests
 
-json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
+json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
 
-socket_handler_ep_tests: socket_handler_ep_tests.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
+socket_handler_ep_tests: socket_handler_ep_tests.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
-clean:
-	rm -f json_tests socket_handler_ep_tests
+all_tests: all_tests.cpp ../src/Json.cpp ../src/Exception.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
+
+clean: ; rm -f json_tests socket_handler_ep_tests all_tests
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,9 @@
-SOCKETS=../src
+SOCKETS=../dist
 
 CXX=g++
 CXXFLAGS=-I$(SOCKETS)/include -std=c++17 `pkg-config --cflags cppunit`
 LIBS_CPPUNIT=`pkg-config --libs cppunit`
-LIBS_SOCKETS=$(LIBS_CPPUNIT) -L$(SOCKETS) -lSockets -lssl -lcrypto -lxml2 -lpthread
+LIBS_SOCKETS=$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2 -lpthread
 
 all: json_tests socket_handler_ep_tests all_tests
 

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -1,0 +1,16 @@
+#define COMBINED_TESTS
+
+#include "json_tests.cpp"
+#include "socket_handler_ep_tests.cpp"
+#include "../demo/tests/http_server_test.cpp"
+
+int main(int argc, char* argv[])
+{
+    std::filesystem::path exe_path = argv[0];
+    std::filesystem::current_path(exe_path.parent_path());
+
+    CppUnit::TextUi::TestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+    return runner.run() ? 0 : 1;
+}
+

--- a/tests/json_tests.cpp
+++ b/tests/json_tests.cpp
@@ -100,9 +100,11 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(JsonConstructorAssignmentTest);
 
+#ifndef COMBINED_TESTS
 int main() {
     CppUnit::TextUi::TestRunner runner;
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
     return runner.run() ? 0 : 1;
 }
+#endif
 

--- a/tests/socket_handler_ep_tests.cpp
+++ b/tests/socket_handler_ep_tests.cpp
@@ -34,9 +34,11 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SocketHandlerEpTest);
 
+#ifndef COMBINED_TESTS
 int main() {
     CppUnit::TextUi::TestRunner runner;
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
     return runner.run() ? 0 : 1;
 }
+#endif
 


### PR DESCRIPTION
## Summary
- add repo-root aware HTTP server tests with max-connections stress case
- enable core dumps for demo HTTP server
- provide combined cppunit test runner alongside existing executables

## Testing
- `make -C demo`
- `make -C tests all_tests`
- `./tests/all_tests`
- `./demo/tests/http_server_test`

------
https://chatgpt.com/codex/tasks/task_e_68a628d9d05c83229342a2558919a646