### PR TITLE
ci: upload distribution artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,18 @@ jobs:
       - name: Build library
         run: make -C src
 
+      - name: Create distribution
+        run: make -C src dist
+
       - name: Run tests
         run: |
           PATH=$PWD/src:$PATH make -C src/tests setup all
           PATH=$PWD/src:$PATH make -C demo/tests setup all
           make -C tests clean all
           ./tests/json_tests
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cpp-sockets-dist
+          path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ./tests/json_tests
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp-sockets-dist
           path: dist/


### PR DESCRIPTION
## Summary
- build and package distribution in CI
- upload `dist/` contents as a GitHub artifact

## Testing
- `make -C src`
- `make -C src dist`
- `PATH=$PWD/src:$PATH make -C src/tests setup all`
- `PATH=$PWD/src:$PATH make -C demo/tests setup all`
- `make -C tests clean all`
- `./tests/json_tests`
- `./tests/socket_handler_ep_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6219a29c08322891cb2f2d4cc85a4