### PR TITLE
Standardize Makefile formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,11 @@
 - Use `$(SOCKETS)/bin/` for helper binaries such as `Sockets-config`.
 - Include headers from `$(SOCKETS)/include/`.
 - Link against libraries in `$(SOCKETS)/lib/`.
+- Set `PLATFORM` to the target platform (for example, `linux-x86-64`) and include both `$(SOCKETS)/Makefile.version` and `$(SOCKETS)/Makefile.Defines.$(PLATFORM)` to reuse library-provided variables and recipes instead of defining them locally.
 
 ## Makefile formatting
-- Any Makefile other the one in the src/ folder should follow the format used by src/Makefile.
+- Any Makefile other than the one in the src/ folder should follow the format used by src/Makefile.
 - Values and dependencies should be indented a total of two tabs, including prefix.
 - Any lines continued with backslash should be respected, and line break preserved.
+- Surround assignment operators (`=`) with a single space on each side.
+- Start recipe commands on a new line rather than using semicolons and indent them with exactly two tabs (the first being make's command prefix).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@
 
 ## Makefile formatting
 - Any Makefile other than the one in the src/ folder should follow the format used by src/Makefile.
-- Values and dependencies should be indented a total of two tabs, including prefix.
+- Values and dependencies must start at the second tab stop (column 17 with tab size 8).
+- If the prefix exceeds two tab stops, end the line with a backslash and continue the value on the next line indented with two tabs.
 - Any lines continued with backslash should be respected, and line break preserved.
 - Surround assignment operators (`=`) with a single space on each side.
 - Start recipe commands on a new line rather than using semicolons and indent them with exactly two tabs (the first being make's command prefix).

--- a/README.md
+++ b/README.md
@@ -19,3 +19,23 @@ make dist PLATFORM=linux-x86-64
 After the `dist` target completes, the top-level `dist/` folder will contain
 `bin`, `lib`, and `include` directories with the compiled utilities, static
 libraries, and header files required to use the library.
+
+## Building the Tests
+
+The test programs in the top-level `tests/` directory depend on the headers,
+libraries, and build recipes produced by the commands above. Attempting to run
+`make` in `tests/` before both building the library and creating the
+distribution will fail because the required `dist/` files are missing. A
+typical flow for building the tests is:
+
+```bash
+cd src
+make PLATFORM=linux-x86-64
+make dist PLATFORM=linux-x86-64
+cd ..
+make -C tests PLATFORM=linux-x86-64
+```
+
+Running `make dist` ensures that the `tests/` Makefile can include
+`dist/Makefile.version` and `dist/Makefile.Defines.<platform>` and link against
+the produced binaries.

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -7,7 +7,8 @@ LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
 
 all:		simple_http_server
 
-simple_http_server: simple_http_server.o
+simple_http_server: \
+		simple_http_server.o
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 clean:

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,13 +1,14 @@
-SOCKETS=../dist
+SOCKETS =		../dist
 
-CXX=g++
-CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include -Wall -std=c++17
-LDFLAGS=
-LIBS=-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
+CXX =		g++
+CXXFLAGS =		`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include -Wall -std=c++17
+LDFLAGS =		
+LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
 
-all: simple_http_server
+all:		simple_http_server
 
-simple_http_server: simple_http_server.o ; $(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
+simple_http_server: simple_http_server.o
+		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-clean: ; rm -f simple_http_server.o simple_http_server
-
+clean:
+		rm -f simple_http_server.o simple_http_server

--- a/demo/tests/Makefile
+++ b/demo/tests/Makefile
@@ -1,14 +1,16 @@
-SOCKETS=../../dist
+SOCKETS =		../../dist
 
-CXX=g++
-CXXFLAGS=`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include `pkg-config --cflags cppunit` -Wall -std=c++17
-LIBS=-L$(SOCKETS)/lib -lSockets `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
+CXX =		g++
+CXXFLAGS =		`$(SOCKETS)/bin/Sockets-config` -I$(SOCKETS)/include `pkg-config --cflags cppunit` -Wall -std=c++17
+LIBS =		-L$(SOCKETS)/lib -lSockets `pkg-config --libs cppunit` -lssl -lcrypto -lpthread
 
-all: http_server_test
+all:		http_server_test
 
-http_server_test: http_server_test.o ; $(CXX) -o $@ $^ $(LIBS)
+http_server_test: http_server_test.o
+		$(CXX) -o $@ $^ $(LIBS)
 
-clean: ; rm -f http_server_test.o http_server_test
+clean:
+		rm -f http_server_test.o http_server_test
 
-setup: ; @echo No longer necessary
-
+setup:
+		@echo No longer necessary

--- a/demo/tests/Makefile
+++ b/demo/tests/Makefile
@@ -6,7 +6,8 @@ LIBS =		-L$(SOCKETS)/lib -lSockets `pkg-config --libs cppunit` -lssl -lcrypto -l
 
 all:		http_server_test
 
-http_server_test: http_server_test.o
+http_server_test: \
+		http_server_test.o
 		$(CXX) -o $@ $^ $(LIBS)
 
 clean:

--- a/src/DevCpp/Makefile
+++ b/src/DevCpp/Makefile
@@ -1,7 +1,7 @@
-INCLUDE =	-I..
+INCLUDE =		-I..
 
-CFLAGS =	-Wall -g -O2 $(INCLUDE) -MD
-CPPFLAGS =	$(CFLAGS)
+CFLAGS =		-Wall -g -O2 $(INCLUDE) -MD
+CPPFLAGS =		$(CFLAGS)
 
 PROGS =		util
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,21 +1,21 @@
-SOCKETS =	../../dist
-PLATFORM =	linux-x86-32
-INCLUDE =	-I$(SOCKETS)/include
+SOCKETS =		../../dist
+PLATFORM =		linux-x86-32
+INCLUDE =		-I$(SOCKETS)/include
 LIBS =		-L$(SOCKETS)/lib -lSockets
 #-L$(SOCKETS) -lSockets 
 
-CFLAGS =        `$(SOCKETS)/bin/Sockets-config`
+CFLAGS =		`$(SOCKETS)/bin/Sockets-config`
 
-CFLAGS +=	-I.
+CFLAGS +=		-I.
 
 include		$(SOCKETS)/Makefile.version
 include		$(SOCKETS)/Makefile.Defines.$(PLATFORM)
 
-CPPFLAGS =	$(CFLAGS)
+CPPFLAGS =		$(CFLAGS)
 
 #LIBS +=		-lsctp
 
-LDFLAGS +=	-rdynamic
+LDFLAGS +=		-rdynamic
 
 PROGS =		events resolve sockets_test base64 semtest \
 		echoserver stressclient http httpd retry resume \
@@ -28,22 +28,22 @@ all:		$(PROGS)
 events:		events.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-resolve:	resolve.o ../libSockets.a 
+resolve:		resolve.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-sockets_test:	sockets_test.o ../libSockets.a 
+sockets_test:		sockets_test.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 base64:		base64.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-semtest:	semtest.o ../libSockets.a 
+semtest:		semtest.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-echoserver:	echoserver.o ../libSockets.a 
+echoserver:		echoserver.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-stressclient:	stressclient.o ../libSockets.a 
+stressclient:		stressclient.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 http:		http.o ../libSockets.a 
@@ -58,7 +58,7 @@ retry:		retry.o ../libSockets.a
 resume:		resume.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-http_post:	http_post.o ../libSockets.a 
+http_post:		http_post.o ../libSockets.a 
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 x:		x.o ../libSockets.a 
@@ -73,22 +73,22 @@ crlf:		crlf.o ../libSockets.a
 https:		https.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-sloppy_http:	sloppy_http.o ../libSockets.a
+sloppy_http:		sloppy_http.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-chunked:	chunked.o ../libSockets.a
+chunked:		chunked.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-threadstress:	threadstress.o ../libSockets.a
+threadstress:		threadstress.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-listener:	listener.o ../libSockets.a
+listener:		listener.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 scanr:		scanr.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-httpd_test:	httpd_test.o ../libSockets.a
+httpd_test:		httpd_test.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 json:		json.o ../libSockets.a
@@ -97,10 +97,10 @@ json:		json.o ../libSockets.a
 detach:		detach.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-bind_address:	bind_address.o ../libSockets.a
+bind_address:		bind_address.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-httpget:	httpget.o ../libSockets.a
+httpget:		httpget.o ../libSockets.a
 		$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 udp:		udp.o ../libSockets.a

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,17 +1,20 @@
-SOCKETS=../dist
+SOCKETS =		../dist
 
-CXX=g++
-CXXFLAGS=-I$(SOCKETS)/include -std=c++17 `pkg-config --cflags cppunit`
-LIBS_CPPUNIT=`pkg-config --libs cppunit`
-LIBS_SOCKETS=$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2 -lpthread
+CXX =		g++
+CXXFLAGS =		-I$(SOCKETS)/include -std=c++17 `pkg-config --cflags cppunit`
+LIBS_CPPUNIT =		`pkg-config --libs cppunit`
+LIBS_SOCKETS =		$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2 -lpthread
 
-all: json_tests socket_handler_ep_tests all_tests
+all:		json_tests socket_handler_ep_tests all_tests
 
-json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
+json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp
+		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
 
-socket_handler_ep_tests: socket_handler_ep_tests.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
+socket_handler_ep_tests: socket_handler_ep_tests.cpp
+		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
-all_tests: all_tests.cpp ../src/Json.cpp ../src/Exception.cpp ; $(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
+all_tests: all_tests.cpp ../src/Json.cpp ../src/Exception.cpp
+		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
-clean: ; rm -f json_tests socket_handler_ep_tests all_tests
-
+clean:
+		rm -f json_tests socket_handler_ep_tests all_tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,13 +7,14 @@ LIBS_SOCKETS =		$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2
 
 all:		json_tests socket_handler_ep_tests all_tests
 
-json_tests: json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp
+json_tests:		json_tests.cpp ../src/Json.cpp ../src/Exception.cpp utility_stub.cpp
 		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_CPPUNIT)
 
-socket_handler_ep_tests: socket_handler_ep_tests.cpp
+socket_handler_ep_tests: \
+		socket_handler_ep_tests.cpp
 		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
-all_tests: all_tests.cpp ../src/Json.cpp ../src/Exception.cpp
+all_tests:		all_tests.cpp ../src/Json.cpp ../src/Exception.cpp
 		$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS_SOCKETS)
 
 clean:


### PR DESCRIPTION
## Summary
- document Makefile formatting conventions and usage of `Makefile.Defines.<platform>` files in `AGENTS.md`

## Testing
- `make -n -C demo`
- `make -n -C demo/tests`
- `make -n -C tests`
- `make -n -C src/tests` (fails: No rule to make target '../../dist/Makefile.Defines.linux-x86-32')
- `make -n -C src/DevCpp`


------
https://chatgpt.com/codex/tasks/task_e_68a8199906948322b1f9809c41313010