### PR TITLE
Standardize Makefile formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 
 all:
-		@$(MAKE)  -C src all dist
+		@$(MAKE) -C src all dist
 
 tests:		all
-		@$(MAKE)  -C ./examples
-		@$(MAKE)  -C ./examples/simple-http-server-demo
-		@$(MAKE)  -C ./tests
+		@$(MAKE) -C ./examples
+		@$(MAKE) -C ./examples/simple-http-server-demo
+		@$(MAKE) -C ./tests
 
 clean:
-		@$(MAKE)  -C ./src clean
-		@$(MAKE)  -C ./examples clean
-		@$(MAKE)  -C ./examples/simple-http-server-demo clean
-		@$(MAKE)  -C ./tests clean
+		@$(MAKE) -C ./src clean
+		@$(MAKE) -C ./examples clean
+		@$(MAKE) -C ./examples/simple-http-server-demo clean
+		@$(MAKE) -C ./tests clean

--- a/examples/artifact-demo/Makefile
+++ b/examples/artifact-demo/Makefile
@@ -9,7 +9,8 @@ CFLAGS =	`$(SOCKETS)/bin/Sockets-config` \
 
 LDFLAGS =	-rdynamic
 
-LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
+LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto \
+		-lpthread
 
 include 	$(SOCKETS)/Makefile.version
 include 	$(SOCKETS)/Makefile.Defines.$(PLATFORM)

--- a/examples/simple-http-server-demo/Makefile
+++ b/examples/simple-http-server-demo/Makefile
@@ -9,7 +9,8 @@ CFLAGS =	`$(SOCKETS)/bin/Sockets-config` \
 
 LDFLAGS =	-rdynamic
 
-LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lpthread
+LIBS =		-L$(SOCKETS)/lib -lSockets -lssl -lcrypto \
+		-lpthread
 
 include		$(SOCKETS)/Makefile.version
 include		$(SOCKETS)/Makefile.Defines.$(PLATFORM)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,8 @@ CFLAGS =	-I$(SOCKETS)/include \
 
 LIBS_CPPUNIT =	`pkg-config --libs cppunit`
 
-LIBS =		$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto -lxml2 -lpthread
+LIBS =		$(LIBS_CPPUNIT) -L$(SOCKETS)/lib -lSockets -lssl -lcrypto \
+		-lxml2 -lpthread
 
 include		$(SOCKETS)/Makefile.version
 include		$(SOCKETS)/Makefile.Defines.$(PLATFORM)


### PR DESCRIPTION
## Summary
- remove extra spacing in root Makefile recipes
- wrap library variables onto continuation lines in tests and example Makefiles for consistent tab-based formatting

## Testing
- `make tests` *(fails: Package cppunit was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a97b4c81cc832280181b35c0c354b9