### PR TITLE
Add Base64 and Utility tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,9 +21,11 @@ all:		$(PROGS)
 SRC4 =		all_tests.cpp \
 		../src/Json.cpp \
 		../src/Exception.cpp \
-		json_tests.cpp \
-		socket_handler_ep_tests.cpp \
-		http_server_test.cpp \
+                json_tests.cpp \
+                socket_handler_ep_tests.cpp \
+                http_server_test.cpp \
+                base64_tests.cpp \
+                utility_tests.cpp \
 
 OBJ4 =		$(patsubst %.cpp, %.o, $(SRC4))
 

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -3,6 +3,8 @@
 #include "json_tests.h"
 #include "socket_handler_ep_tests.h"
 #include "http_server_test.h"
+#include "base64_tests.h"
+#include "utility_tests.h"
 
 int main(int , char* argv[])
 {

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -1,0 +1,3 @@
+#include "base64_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(Base64Test);

--- a/tests/base64_tests.h
+++ b/tests/base64_tests.h
@@ -1,0 +1,34 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/Base64.h"
+#include <string>
+
+class Base64Test : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(Base64Test);
+    CPPUNIT_TEST(testEncode);
+    CPPUNIT_TEST(testDecode);
+    CPPUNIT_TEST(testDecodeLength);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testEncode() {
+        Base64 b;
+        std::string out;
+        b.encode("hello world", out, false);
+        CPPUNIT_ASSERT_EQUAL(std::string("aGVsbG8gd29ybGQ="), out);
+    }
+
+    void testDecode() {
+        Base64 b;
+        std::string out;
+        b.decode("aGVsbG8gd29ybGQ=", out);
+        CPPUNIT_ASSERT_EQUAL(std::string("hello world"), out);
+    }
+
+    void testDecodeLength() {
+        Base64 b;
+        size_t len = b.decode_length("aGVsbG8gd29ybGQ=");
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(11), len);
+    }
+};
+

--- a/tests/utility_tests.cpp
+++ b/tests/utility_tests.cpp
@@ -1,0 +1,3 @@
+#include "utility_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(UtilityTest);

--- a/tests/utility_tests.h
+++ b/tests/utility_tests.h
@@ -1,0 +1,23 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/Utility.h"
+#include <string>
+
+class UtilityTest : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(UtilityTest);
+    CPPUNIT_TEST(testHex2Unsigned);
+    CPPUNIT_TEST(testAtoi64);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testHex2Unsigned() {
+        CPPUNIT_ASSERT_EQUAL(0x1Au, Utility::hex2unsigned("1A"));
+        CPPUNIT_ASSERT_EQUAL(0xFFu, Utility::hex2unsigned("ff"));
+    }
+
+    void testAtoi64() {
+        CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(0), Utility::atoi64("0"));
+        CPPUNIT_ASSERT_EQUAL(static_cast<uint64_t>(123456789012345ULL), Utility::atoi64("123456789012345"));
+    }
+};
+


### PR DESCRIPTION
## Summary
- add Base64 tests for encoding, decoding and length helpers
- cover Utility hex and 64-bit conversion helpers
- wire new test fixtures into combined test runner

## Testing
- `make -C tests`
- `./tests/all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a9dfbf101083228037064198dc20a0