### PR TITLE
Print test names during CppUnit runs

### DIFF
--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -5,6 +5,17 @@
 #include "http_server_test.h"
 #include "base64_tests.h"
 #include "utility_tests.h"
+#include <cppunit/TestListener.h>
+#include <cppunit/Test.h>
+#include <cppunit/TestResult.h>
+#include <iostream>
+
+class VerboseTestProgressListener : public CppUnit::TestListener {
+public:
+    void startTest(CppUnit::Test* test) override {
+        std::cout << "Running: " << test->getName() << std::endl;
+    }
+};
 
 int main(int , char* argv[])
 {
@@ -12,7 +23,9 @@ int main(int , char* argv[])
     std::filesystem::current_path(exe_path.parent_path());
 
     CppUnit::TextUi::TestRunner runner;
+    VerboseTestProgressListener progress;
+    runner.eventManager().addListener(&progress);
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
-    return runner.run() ? 0 : 1;
+    return runner.run("", false, true, false) ? 0 : 1;
 }
 


### PR DESCRIPTION
## Summary
- add custom CppUnit listener that prints each test name during execution

## Testing
- `./tests/all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ac4f0f09208322b48074fedea76077