### PR TITLE
docs: document platform values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,19 @@
 - Use `$(SOCKETS)/bin/` for helper binaries such as `Sockets-config`.
 - Include headers from `$(SOCKETS)/include/`.
 - Link against libraries in `$(SOCKETS)/lib/`.
-- Set `PLATFORM` to the target platform (for example, `linux-x86-64`). Planned targets include `win32`, `win64`, `linux-x64-64`, `linux-x86-32`, and `raspberry-pi` (ARM).
+- Set `PLATFORM` to the target platform (for example, `linux-x86-64`). Planned targets include `win32`, `win64`, `linux-x64-64`,
+  `linux-x86-32`, and `raspberry-pi` (ARM).
+
+  Supported values include:
+  - `linux-x86-64`
+  - `linux-x86-32`
+  - `darwin-arm64`
+  - `win32`
+  - `win64`
+  - `raspberry-pi`
+
+  To derive a value, combine the lower-cased output of `uname -s` with `uname -m` (for example, `$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)`).
+  The `Sockets-config` utility in `$(SOCKETS)/bin/` automatically prints the current platform and flags, and can be used to verify the selected `PLATFORM`.
 - Define `INCLUDE`, `LIBS`, and `CFLAGS` before including `$(SOCKETS)/Makefile.version` and `$(SOCKETS)/Makefile.Defines.$(PLATFORM)` to reuse library-provided variables and recipes. These files append library-specific flags and copy `CFLAGS` to `CPPFLAGS` for C++ builds.
 
 ```make
@@ -27,3 +39,4 @@ include        $(SOCKETS)/Makefile.Defines.$(PLATFORM)
 - Any lines continued with backslash should be respected, and line break preserved.
 - Surround assignment operators (`=`) with a single space on each side.
 - Start recipe commands on a new line rather than using semicolons and indent them with exactly two tabs (the first being make's command prefix).
+


### PR DESCRIPTION
## Summary
- document supported PLATFORM values in AGENTS.md
- describe how to derive PLATFORM and mention Sockets-config helper

## Testing
- `make tests` (fails: Package 'cppunit' not found)
- `make -C tests` (fails: Package 'cppunit' not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad659138388322947a2e1f3add3aa7