### PR TITLE
Add Python utility for PLATFORM detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tests/all_tests
 # ignore dist folder content
 dist/
 examples/artifact-demo/dist/
+
+# Python cache
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all:
 		@$(MAKE) -C src all dist
 
 tests:		all
+		python3 tests/test_detect_platform.py
 		@$(MAKE) -C ./examples
 		@$(MAKE) -C ./examples/simple-http-server-demo
 		@$(MAKE) -C ./tests

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ The C++ class library is a versatile and user-friendly tool for network programm
 
 The library was designed to simplify the complexities of network programming and provide a single-threaded approach to managing multiple sockets. Instead of using the traditional C API, it provides a convenient Socket class that handles address translations and owns the file descriptor. The library also features callback methods such as OnRead(), OnWrite(), OnConnect(), and OnAccept(), to report events and handle logic related to the sockets. The sockets are monitored and managed using the Select() method in a SocketHandler class. The library has been tested on Linux, Windows 2000, and to some extent on Solaris and Mac OS X.
 
+## Determining the PLATFORM Value
+
+The Makefiles in this repository use a `PLATFORM` variable to select
+platform-specific build settings. The `detect_platform.py` helper can be
+used to print the appropriate value for the current machine:
+
+```bash
+python detect_platform.py
+```
+
+The script outputs strings such as `linux-x86-64`, `win64`, or
+`raspberry-pi`.
+
 ## Building and Creating a Distribution
 
 The source code for the library lives in the `src/` directory. To build the

--- a/detect_platform.py
+++ b/detect_platform.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Derive the PLATFORM string used by the Sockets library.
+
+This script inspects the current operating system and machine
+architecture and prints the corresponding PLATFORM identifier used
+by the library's build system.
+"""
+from __future__ import annotations
+import platform
+from pathlib import Path
+
+def get_platform() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "windows":
+        return "win64" if "64" in machine else "win32"
+
+    if system == "darwin":
+        if machine == "arm64":
+            return "darwin-arm64"
+        if machine in ("x86_64",):
+            return "darwin-x86-64"
+
+    if system == "linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux-x86-64"
+        if machine in ("i386", "i686", "x86"):
+            return "linux-x86-32"
+        if machine.startswith("arm") or machine.startswith("aarch64"):
+            try:
+                cpuinfo = Path("/proc/cpuinfo").read_text().lower()
+                if "raspberry pi" in cpuinfo:
+                    return "raspberry-pi"
+            except OSError:
+                pass
+
+    return f"{system}-{machine}"
+
+
+if __name__ == "__main__":
+    print(get_platform())

--- a/tests/test_detect_platform.py
+++ b/tests/test_detect_platform.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import detect_platform
+
+
+class DetectPlatformTests(unittest.TestCase):
+    def test_windows_64(self):
+        with patch("platform.system", return_value="Windows"), \
+             patch("platform.machine", return_value="AMD64"):
+            self.assertEqual(detect_platform.get_platform(), "win64")
+
+    def test_macos_arm64(self):
+        with patch("platform.system", return_value="Darwin"), \
+             patch("platform.machine", return_value="arm64"):
+            self.assertEqual(detect_platform.get_platform(), "darwin-arm64")
+
+    def test_linux_x86_64(self):
+        with patch("platform.system", return_value="Linux"), \
+             patch("platform.machine", return_value="x86_64"):
+            self.assertEqual(detect_platform.get_platform(), "linux-x86-64")
+
+    def test_raspberry_pi(self):
+        cpuinfo = "model name\t: Raspberry Pi\n"
+        with patch("platform.system", return_value="Linux"), \
+             patch("platform.machine", return_value="armv7l"), \
+             patch("pathlib.Path.read_text", return_value=cpuinfo):
+            self.assertEqual(detect_platform.get_platform(), "raspberry-pi")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `detect_platform.py` to determine appropriate PLATFORM string across operating systems
- document how to derive the PLATFORM value in the README

## Testing
- `make tests` *(fails: Package 'cppunit' not found)*
- `./tests/all_tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad728734448322832941dcc0ff4290