### PR TITLE
docs: add C++ formatting example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,17 @@ make tests
 - Use Microsoft brace style: place opening braces on a new line and align closing braces with the start of the block.
 - Preserve existing source file formatting unless explicitly requested to change it.
 
+Example:
+
+```cpp
+int main()
+{
+	if (should_run)
+	{
+		run();
+	}
+
+	return 0;
+}
+```
+


### PR DESCRIPTION
## Summary
- document a correctly formatted C++ snippet following project brace style

## Testing
- `make tests`
- `./tests/all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad9f0b72fc8322a93f20ac52be062d