### PR TITLE
Add basic socket unit tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,11 +21,15 @@ all:		$(PROGS)
 SRC4 =		all_tests.cpp \
 		../src/Json.cpp \
 		../src/Exception.cpp \
-                json_tests.cpp \
-                socket_handler_ep_tests.cpp \
-                http_server_test.cpp \
-                base64_tests.cpp \
-                utility_tests.cpp \
+		json_tests.cpp \
+		socket_handler_ep_tests.cpp \
+		http_server_test.cpp \
+		base64_tests.cpp \
+		utility_tests.cpp \
+		tcp_socket_tests.cpp \
+		udp_socket_tests.cpp \
+		socket_handler_tests.cpp \
+		ssl_initializer_tests.cpp \
 
 OBJ4 =		$(patsubst %.cpp, %.o, $(SRC4))
 

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -5,6 +5,10 @@
 #include "http_server_test.h"
 #include "base64_tests.h"
 #include "utility_tests.h"
+#include "tcp_socket_tests.h"
+#include "udp_socket_tests.h"
+#include "socket_handler_tests.h"
+#include "ssl_initializer_tests.h"
 #include <cppunit/TestListener.h>
 #include <cppunit/Test.h>
 #include <cppunit/TestResult.h>

--- a/tests/socket_handler_tests.cpp
+++ b/tests/socket_handler_tests.cpp
@@ -1,0 +1,3 @@
+#include "socket_handler_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(SocketHandlerTest);

--- a/tests/socket_handler_tests.h
+++ b/tests/socket_handler_tests.h
@@ -1,0 +1,39 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/SocketHandler.h"
+#include "../src/StdoutLog.h"
+#include "../src/TcpSocket.h"
+
+class SocketHandlerTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(SocketHandlerTest);
+	CPPUNIT_TEST(testConstruct);
+	CPPUNIT_TEST(testSelectWithoutSockets);
+	CPPUNIT_TEST(testAddAndRemove);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testConstruct()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		CPPUNIT_ASSERT_EQUAL(0, (int)h.GetCount());
+	}
+
+	void testSelectWithoutSockets()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		CPPUNIT_ASSERT_EQUAL(0, h.Select(0, 0));
+	}
+
+	void testAddAndRemove()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		TcpSocket s(h);
+		h.Add(&s);
+		CPPUNIT_ASSERT_EQUAL(1, (int)h.GetCount());
+		h.ISocketHandler_Del(&s);
+	}
+};

--- a/tests/ssl_initializer_tests.cpp
+++ b/tests/ssl_initializer_tests.cpp
@@ -1,0 +1,3 @@
+#include "ssl_initializer_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(SSLInitializerTest);

--- a/tests/ssl_initializer_tests.h
+++ b/tests/ssl_initializer_tests.h
@@ -1,0 +1,17 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/SSLInitializer.h"
+
+class SSLInitializerTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(SSLInitializerTest);
+	CPPUNIT_TEST(testConstruct);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testConstruct()
+	{
+		SSLInitializer init;
+		CPPUNIT_ASSERT(init.bio_err != nullptr);
+	}
+};

--- a/tests/tcp_socket_tests.cpp
+++ b/tests/tcp_socket_tests.cpp
@@ -1,0 +1,3 @@
+#include "tcp_socket_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TcpSocketTest);

--- a/tests/tcp_socket_tests.h
+++ b/tests/tcp_socket_tests.h
@@ -1,0 +1,31 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/TcpSocket.h"
+#include "../src/SocketHandler.h"
+#include "../src/StdoutLog.h"
+#include <netinet/in.h>
+
+class TcpSocketTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(TcpSocketTest);
+	CPPUNIT_TEST(testProtocol);
+	CPPUNIT_TEST(testOpenInvalidHost);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testProtocol()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		TcpSocket s(h);
+		CPPUNIT_ASSERT_EQUAL(static_cast<int>(IPPROTO_TCP), s.Protocol());
+	}
+
+	void testOpenInvalidHost()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		TcpSocket s(h);
+		CPPUNIT_ASSERT(!s.Open("invalid.host", 1));
+	}
+};

--- a/tests/udp_socket_tests.cpp
+++ b/tests/udp_socket_tests.cpp
@@ -1,0 +1,3 @@
+#include "udp_socket_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(UdpSocketTest);

--- a/tests/udp_socket_tests.h
+++ b/tests/udp_socket_tests.h
@@ -1,0 +1,21 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include "../src/UdpSocket.h"
+#include "../src/SocketHandler.h"
+#include "../src/StdoutLog.h"
+
+class UdpSocketTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(UdpSocketTest);
+	CPPUNIT_TEST(testOpenInvalidHost);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testOpenInvalidHost()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		UdpSocket s(h);
+		CPPUNIT_ASSERT(!s.Open("invalid.host", 1));
+	}
+};


### PR DESCRIPTION
## Summary
- add unit tests for TcpSocket, UdpSocket, SocketHandler, and SSLInitializer
- wire new test suites into build and runner

## Testing
- `make -C tests`
- `./tests/all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68aef2a94d9c83228f62037a74dd2b59