### PR TITLE
ci: limit push workflow to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
### Motivation
- Restrict CI `push` events to the `main` branch to avoid running the workflow on other branches.

### Description
- Modify `.github/workflows/ci.yml` to add `on.push.branches: [main]` and keep the `pull_request` trigger unchanged.

### Testing
- No automated tests were run because this change only updates the workflow trigger configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0086e3c3b883228b8a9e486d093109)