### PR TITLE
Add cppunit regression test for HttpClientSocket negative Content-Length parsing

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,6 +30,7 @@ SRC4 =		all_tests.cpp \
 		udp_socket_tests.cpp \
 		socket_handler_tests.cpp \
 		ssl_initializer_tests.cpp \
+		http_client_socket_vuln_tests.cpp \
 
 OBJ4 =		$(patsubst %.cpp, %.o, $(SRC4))
 

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -9,6 +9,7 @@
 #include "udp_socket_tests.h"
 #include "socket_handler_tests.h"
 #include "ssl_initializer_tests.h"
+#include "http_client_socket_vuln_tests.h"
 #include <cppunit/TestListener.h>
 #include <cppunit/Test.h>
 #include <cppunit/TestResult.h>

--- a/tests/http_client_socket_vuln_tests.cpp
+++ b/tests/http_client_socket_vuln_tests.cpp
@@ -1,0 +1,3 @@
+#include "http_client_socket_vuln_tests.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(HttpClientSocketVulnTest);

--- a/tests/http_client_socket_vuln_tests.h
+++ b/tests/http_client_socket_vuln_tests.h
@@ -1,0 +1,24 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <limits>
+#include "../src/HttpClientSocket.h"
+#include "../src/SocketHandler.h"
+#include "../src/StdoutLog.h"
+
+class HttpClientSocketVulnTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(HttpClientSocketVulnTest);
+	CPPUNIT_TEST(testNegativeContentLengthWrapsToHugeSizeT);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testNegativeContentLengthWrapsToHugeSizeT()
+	{
+		StdoutLog log;
+		SocketHandler h(&log);
+		HttpClientSocket s(h, "http://127.0.0.1/");
+
+		s.OnHeader("content-length", "-1");
+
+		CPPUNIT_ASSERT_EQUAL(std::numeric_limits<size_t>::max(), s.GetContentLength());
+	}
+};


### PR DESCRIPTION
### Motivation
- A `HttpClientSocket` parsing issue was identified where `OnHeader` uses `atoi` to parse the `Content-Length` header into `m_content_length` (a `size_t`), allowing negative values (for example `"-1"`) to wrap to a large unsigned value and affect subsequent allocations and control flow.
- The change adds regression coverage to detect this unsafe behaviour without modifying library source code so future changes can prevent regressions.

### Description
- Added a new CppUnit test fixture `HttpClientSocketVulnTest` in `tests/http_client_socket_vuln_tests.h` that calls `s.OnHeader("content-length", "-1")` and asserts the parsed value equals `std::numeric_limits<size_t>::max()`.
- Added a small test translation unit `tests/http_client_socket_vuln_tests.cpp` to register the suite with the test runner via `CPPUNIT_TEST_SUITE_REGISTRATION`.
- Included the new test header in the combined test entry point by adding `#include "http_client_socket_vuln_tests.h"` to `tests/all_tests.cpp` and added `http_client_socket_vuln_tests.cpp` to `tests/Makefile` so it is built into `all_tests`.

### Testing
- Ran `make tests`; compilation progressed through the `src/` build and created library artifacts, but the full test build failed due to external packaging/setup steps in the existing Makefiles (a fetch/zip step returned HTTP 404 and `dist/Makefile.Defines.linux-x86-64` was not available), so the combined CppUnit binary was not produced.
- The repository-level Python test `python3 tests/test_detect_platform.py` executed and passed (`4 tests OK`) during the `make tests` run.
- The new CppUnit test was compiled into the project sources but the full test runner execution of the new test did not complete due to the Makefile/environment failure described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a730414083229780054a51a4f5ec)